### PR TITLE
feat(sidebar): 반응형 사이드바 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import "./globals.css";
 import ClientLayout from "@/components/basic/ClientLayout";
 import Header from "@/components/main/Header";
-import Sidebar from "@/components/main/Sidebar";
 import CurrentRoute from "@/components/main/CurrentRoute";
 import { ThemeProvider } from "@/components/basic/themeProvider";
+import ResponsiveSidebar from "@/components/main/Responsive";
 
 export const metadata: Metadata = {
     title: "미리내를 잇는 코드",
@@ -27,7 +27,7 @@ export default function RootLayout({
                 >
                     <ClientLayout>
                         <main className="w-full dark:text-invert bg-gray-600 border-8 border-gray-600 rounded-t-xl overflow-auto flex flex-row justify-between gap-2 flex-1">
-                            <Sidebar />
+                            <ResponsiveSidebar />
                             <section className="flex flex-col flex-1 gap-2 overflow-hidden">
                                 <Header />
                                 {/* Rendering 될 내용 */}

--- a/src/components/basic/ThemeToggle.tsx
+++ b/src/components/basic/ThemeToggle.tsx
@@ -44,7 +44,7 @@ export default function ThemeToggle() {
             variant="ghost"
             size="icon"
             onClick={toggleTheme}
-            className="rounded-xl bg-gray-200 px-4 py-2 text-sm dark:bg-gray-800 dark:text-white transition-colors"
+            className="rounded-xl px-4 py-2 text-sm transition-colors"
         >
             {isDark ? (
                 <Sun

--- a/src/components/main/Responsive.tsx
+++ b/src/components/main/Responsive.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Menu, XIcon } from "lucide-react";
+import { useState } from "react";
+import Sidebar from "./Sidebar";
+import { Button } from "../ui/button";
+import { cn } from "@/lib/utils";
+
+export default function ResponsiveSidebar() {
+    const [sidebarOpen, setSidebarOpen] = useState(false);
+
+    return (
+        <>
+            {/* 모바일: 상단 왼쪽 토글 버튼 */}
+            <Button
+                variant="ghost"
+                className="fixed top-4.5 right-16 md:hidden rounded-xl px-4 py-2 text-sm transition-colors"
+                onClick={() => setSidebarOpen(true)}
+                aria-label="Open Sidebar"
+            >
+                <Menu className="h-[1.2rem] w-[1.2rem]" />
+            </Button>
+
+            {/* PC/태블릿: 항상 보이는 사이드 바 */}
+            <div className="w-fit hidden md:block">
+                <Sidebar />
+            </div>
+
+            {/* 모바일: 오버레이 사이드바 */}
+            {sidebarOpen && (
+                <div className="fixed inset-0 z-40 flex">
+                    {/* 오버레이 배경 */}
+                    <div
+                        className="fixed inset-0 bg-black/40"
+                        onClick={() => setSidebarOpen(false)}
+                        aria-label="Close sidebar"
+                    />
+                    {/* 사이드바 패널 */}
+                    <div
+                        className={cn(
+                            "relative z-50 w-48 max-w-full pt-4 bg-background shadow-lg h-full animate-in slide-in-from-left duration-300"
+                        )}
+                    >
+                        {/* 닫기 버튼 */}
+                        <button
+                            className="absolute top-4 right-4 hover:opacity-60"
+                            onClick={() => setSidebarOpen(false)}
+                            aria-label="Close Sidebar"
+                        >
+                            <XIcon className="w-6 h-6" />
+                        </button>
+                        <Sidebar />
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/main/Sidebar.tsx
+++ b/src/components/main/Sidebar.tsx
@@ -33,11 +33,11 @@ export default function Sidebar() {
         <aside
             className={`p-2 bg-background transition-[width] duration-300 ease-in-out overflow-x-hidden overflow-y-auto ${
                 isOpen ? "w-48" : "w-14"
-            } flex flex-col justify-between`}
+            } flex flex-col justify-between h-full`}
         >
             <div className="flex flex-col justify-between gap-5">
                 <div className="flex justify-end">
-                    <button className="mr-2" onClick={() => setIsOpen(!isOpen)}>
+                    <button className="mr-2 hidden md:block" onClick={() => setIsOpen(!isOpen)}>
                         <ArrowLeftIcon
                             className={cn(
                                 isOpen ? "" : "-rotate-180",


### PR DESCRIPTION
이전 사이드 바 컴포넌트를 그대로 사용(시간 절약)하여 반응형 컴포넌트 제작

추후 반응형 컴포넌트를 총괄 관리할 Responsive.tsx 파일 생성하여 내부에 작성

사이드바 여닫을때 애니메이션 적용하여 사용성 증대
모바일의 경우 우측 상단-테마토글 버튼 좌측에 사이드바 토글 버튼 생성
이유 : 헤더의 프로필 내용 간섭 및 자연스러운 연출을 위해 버튼 옆에 나란히 생성
방식 : fixed top-4.5 right-16 으로 헤더에 추가하는 것이 아닌 화면 상에서 위치를 fix시킴 tw-animate-css 의 animate 사용-> className="animate-in slide-in-from-left duration-300"

Closes #8 