### PR TITLE
feat(layout): 모바일 화면 크기 고려하여 레이아웃 조정 & 페이지 이동 시 사이드 바 닫힘

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
 }>) {
     return (
         <html lang="ko" suppressHydrationWarning>
-            <body className="min-h-screen max-h-screen w-full flex flex-col justify-center p-2 font-galmuri9 antialiased overflow-x-hidden">
+            <body className="min-h-dvh max-h-dvh w-full flex flex-col justify-center p-2 font-galmuri9 antialiased overflow-x-hidden">
                 <ThemeProvider
                     attribute="class"
                     defaultTheme="system"

--- a/src/components/main/Responsive.tsx
+++ b/src/components/main/Responsive.tsx
@@ -1,13 +1,22 @@
 "use client";
 
 import { Menu, XIcon } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Sidebar from "./Sidebar";
 import { Button } from "../ui/button";
 import { cn } from "@/lib/utils";
+import { usePathname } from "next/navigation";
 
 export default function ResponsiveSidebar() {
     const [sidebarOpen, setSidebarOpen] = useState(false);
+
+    // 페이지 이동 시 사이드바가 자동으로 닫히도록 설정
+    // (사이드 바를 통해 페이지 이동 시 바로 해당 페이지 콘텐츠를 보여주기 위함)
+    const pathname = usePathname();
+
+    useEffect(() => {
+        setSidebarOpen(false);
+    }, [pathname]); // 페이지 이동 시 변경되는 pathname을 감지하여 사이드바 닫힘
 
     return (
         <>


### PR DESCRIPTION
- 레이아웃 높이 조절 - 모바일 화면에 꽉차도록
- 페이지 이동 시 사이드 바 닫힘

1. h-dvh 사용하여 화면에 따라 동적으로 꽉차도록 지정
2. hook을 사용하여 페이지 경로 변경 감지 시 사이드바가 닫히도록 설정

Close #11 